### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,10 +33,10 @@ java {
 }
 
 dependencies {
-    api("com.newrelic.agent.java:newrelic-api:5.13.0")
-    implementation("com.newrelic.telemetry:telemetry:0.6.1")
-    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.6.1")
-    implementation("com.newrelic:jfr-mappers:0.3.0")
+    api("com.newrelic.agent.java:newrelic-api:6.1.0")
+    implementation("com.newrelic.telemetry:telemetry:0.8.0")
+    implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.8.0")
+    implementation("com.newrelic:jfr-mappers:0.5.0")
     implementation("org.slf4j:slf4j-api:1.7.26")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")

--- a/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -15,7 +15,7 @@ public class StaticLoggerBinder implements LoggerFactoryBinder {
 
   private static final StaticLoggerBinder SINGLETON = new StaticLoggerBinder();
 
-  public static final StaticLoggerBinder getSingleton() {
+  public static StaticLoggerBinder getSingleton() {
     return SINGLETON;
   }
 


### PR DESCRIPTION
We need to cut a release of this shortly to pick up the changes to the sdk.  
This does the dependency updates for:
* telemetry sdk -> 0.8.0
* jfr-mappers -> 0.5.0
* agent -> 6.1.0