### PR TITLE
use standard gradle prop names for signing

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,4 +10,4 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          command: test --all-sub-projects
+          command: test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,11 +119,3 @@ publishing {
         }
     }
 }
-
-signing {
-    val signingKey: String? = System.getenv("SIGNING_KEY")
-    val signingKeyId: String? = System.getenv("SIGNING_KEY_ID")
-    val signingPassword: String? = System.getenv("SIGNING_PASSWORD")
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    sign(publishing.publications["mavenJava"])
-}


### PR DESCRIPTION
The last main merge failed to publish a snapshot, because the signing secret information was being customized.  Removing this should allow it to leverage the gradle defaults as specified in the github actions files.